### PR TITLE
decrease batch timeout to 100ms

### DIFF
--- a/templates/configtx-template.yaml
+++ b/templates/configtx-template.yaml
@@ -37,7 +37,7 @@ Orderer: &OrdererDefaults
         - orderer.${DOMAIN}:7050
 
     # Batch Timeout: The amount of time to wait before creating a batch
-    BatchTimeout: 2s
+    BatchTimeout: 100ms
 
     # Batch Size: Controls the number of messages batched into a block
     BatchSize:


### PR DESCRIPTION
re-applying the 100ms bacth-timeout after it was reverted as part of the rexray undo